### PR TITLE
allow loading of an existing agent

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ import Agent from './agent'
 import Animator from './animator'
 import Queue from './queue'
 import Balloon from './balloon'
-import { load, ready, soundsReady } from './load'
+import { load, loadExistingAgent, ready, soundsReady } from './load'
 
 const clippy = {
     Agent,
@@ -11,7 +11,8 @@ const clippy = {
     Balloon,
     load,
     ready,
-    soundsReady
+    soundsReady,
+    loadExistingAgent,
 }
 
 export default clippy
@@ -19,5 +20,3 @@ export default clippy
 if (typeof window !== 'undefined') {
     window.clippy = clippy
 }
-
-

--- a/lib/load.js
+++ b/lib/load.js
@@ -24,6 +24,7 @@ export class load {
         // wrapper to the success callback
         let cb = function () {
             let a = new Agent(path, data, sounds);
+            load._agents[name] = a
             successCb(a);
         };
 
@@ -105,6 +106,7 @@ export class load {
 load._maps = {};
 load._sounds = {};
 load._data = {};
+load._agents = {}
 
 export function ready (name, data) {
     let dfd = load._getAgentDfd(name);
@@ -118,4 +120,8 @@ export function soundsReady (name, data) {
     }
 
     dfd.resolve(data);
+}
+
+export function loadExistingAgent (name) {
+    return load._agents[name]
 }


### PR DESCRIPTION
It is currently not possible to grab a reference to an existing clippy. This PR exposes a new function `loadExistingAgent` that allows for this.